### PR TITLE
src: Add restock flag to weapon_set (again)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -499,7 +499,7 @@ void init() {
 	chunk_init();
 	grenade_init();
 
-	weapon_set();
+	weapon_set(false);
 
 	rpc_init();
 }

--- a/src/network.c
+++ b/src/network.c
@@ -285,7 +285,7 @@ void read_PacketStateData(void* data, int len) {
 	local_player_health = 100;
 	local_player_blocks = 50;
 	local_player_grenades = 3;
-	weapon_set();
+	weapon_set(false);
 
 	players[local_player_id].block.red = 111;
 	players[local_player_id].block.green = 111;
@@ -401,7 +401,7 @@ void read_PacketCreatePlayer(void* data, int len) {
 			local_player_blocks = 50;
 			local_player_grenades = 3;
 			local_player_lasttool = TOOL_GUN;
-			weapon_set();
+			weapon_set(false);
 		}
 	}
 }
@@ -652,7 +652,7 @@ void read_PacketRestock(void* data, int len) {
 	local_player_health = 100;
 	local_player_blocks = 50;
 	local_player_grenades = 3;
-	weapon_set();
+	weapon_set(true);
 	sound_create(SOUND_LOCAL, &sound_switch, 0.0F, 0.0F, 0.0F);
 }
 

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -184,8 +184,10 @@ struct kv6_t* weapon_casing(int gun) {
 	}
 }
 
-void weapon_set() {
- 	local_player_ammo = weapon_ammo(players[local_player_id].weapon);
+void weapon_set(bool restock) {
+	if(!restock)
+		local_player_ammo = weapon_ammo(players[local_player_id].weapon);
+
 	local_player_ammo_reserved = weapon_ammo_reserved(players[local_player_id].weapon);
 	weapon_reload_inprogress = 0;
 }

--- a/src/weapon.h
+++ b/src/weapon.h
@@ -25,7 +25,7 @@
 #include "model.h"
 
 void weapon_update(void);
-void weapon_set(void);
+void weapon_set(bool restock);
 void weapon_reload(void);
 int weapon_reloading(void);
 int weapon_can_reload(void);


### PR DESCRIPTION
When restocking we do not want to set
the ammo of the player to max.
Player has to do that manually and reload.

This would give player 1 more full clip
and skip a restock wait time in case of no
ammo thus lets fix this so we dont
give any player any advantage